### PR TITLE
Fix bug to enable undo commands to delete database records

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -278,6 +278,7 @@ def delete_from_database(database_uri, database_table, image_path, filename_list
 
     # Calculate the path where the image is backed up to (i.e. raw data)
     img_backup_path, _ = get_backup_path(image_path, image_backup_path)
+    img_backup_path = img_backup_path.replace(os.path.expanduser('~'), '~')  # save with soft-coded path (cf commit 2743a7ab)
 
     delete_query = f'''
                     DELETE FROM {database_table}


### PR DESCRIPTION
This change fixes a latent bug in that was accidentally introduced in May 2021. The undo command (Shift+Z) is supposed to remove database records that were inserted to represent that group, because our decision(s) may change when we re-save the group for a second / third / etc time.

However, in commit 2743a7ab I changed the format of the inserted paths to use ~ by way of soft-coding their paths when being entered into the database. Unfortunately, I did not change the corresponding deletion, causing the deletion to fail to find a match. This change fixes that problem going forward. 

_However, there have been no deletions in the `duplicates` table since May 2021!_ Luckily, this just leaves us with duplicates, which can be carefully deleted (see comment following).