### PR TITLE
Shortcuts for jumping left and right

### DIFF
--- a/assets/app_js.js
+++ b/assets/app_js.js
@@ -85,4 +85,22 @@ function clickButtonFunction(event){
   if (event.key === 'y') {
     document.getElementById("jump-right-7-cells-button").click();
   }
+  if (event.key === 'Q') {
+    document.getElementById("jump-left-2-cells-button").click();
+  }
+  if (event.key === 'W') {
+    document.getElementById("jump-left-3-cells-button").click();
+  }
+  if (event.key === 'E') {
+    document.getElementById("jump-left-4-cells-button").click();
+  }
+  if (event.key === 'R') {
+    document.getElementById("jump-left-5-cells-button").click();
+  }
+  if (event.key === 'T') {
+    document.getElementById("jump-left-6-cells-button").click();
+  }
+  if (event.key === 'Y') {
+    document.getElementById("jump-left-7-cells-button").click();
+  }
 }

--- a/assets/app_js.js
+++ b/assets/app_js.js
@@ -31,6 +31,31 @@ function clickButtonFunction(event){
   if(event.key == 'Z'){
     document.getElementById("undo-button").click();
   }
+  // Note: important that these ctrl+X shortcuts come before simple X ones (b/c using ifs not else ifs)
+  if (event.ctrlKey && event.key === '2') {
+    document.getElementById("jump-right-2-cells-button").click();
+  }
+  if (event.ctrlKey && event.key === '3') {
+    document.getElementById("jump-right-3-cells-button").click();
+  }
+  if (event.ctrlKey && event.key === '4') {
+    document.getElementById("jump-right-4-cells-button").click();
+  }
+  if (event.ctrlKey && event.key === '5') {
+    document.getElementById("jump-right-5-cells-button").click();
+  }
+  if (event.ctrlKey && event.key === '6') {
+    document.getElementById("jump-right-6-cells-button").click();
+  }
+  if (event.ctrlKey && event.key === '7') {
+    document.getElementById("jump-right-7-cells-button").click();
+  }
+  if (event.ctrlKey && event.key === '8') {
+    document.getElementById("jump-right-8-cells-button").click();
+  }
+  if (event.ctrlKey && event.key === '9') {
+    document.getElementById("jump-right-9-cells-button").click();
+  }
   if(event.key == '1'){
     document.getElementById("select-row-upto-1-button").click();
   }

--- a/assets/app_js.js
+++ b/assets/app_js.js
@@ -34,25 +34,6 @@ function clickButtonFunction(event){
   if(event.key == 'Z'){
     document.getElementById("undo-button").click();
   }
-  // Note: important that these ctrl+X shortcuts come before simple X ones (b/c using ifs not else ifs)
-  if (event.key === 'q') {
-    document.getElementById("jump-right-2-cells-button").click();
-  }
-  if (event.key === 'w') {
-    document.getElementById("jump-right-3-cells-button").click();
-  }
-  if (event.key === 'e') {
-    document.getElementById("jump-right-4-cells-button").click();
-  }
-  if (event.key === 'r') {
-    document.getElementById("jump-right-5-cells-button").click();
-  }
-  if (event.key === 't') {
-    document.getElementById("jump-right-6-cells-button").click();
-  }
-  if (event.key === 'y') {
-    document.getElementById("jump-right-7-cells-button").click();
-  }
   if(event.key == '1'){
     document.getElementById("select-row-upto-1-button").click();
   }
@@ -85,5 +66,23 @@ function clickButtonFunction(event){
   }
   if(event.key == 'A'){
     document.getElementById("select-row-upto-1000-button").click();
+  }
+  if (event.key === 'q') {
+    document.getElementById("jump-right-2-cells-button").click();
+  }
+  if (event.key === 'w') {
+    document.getElementById("jump-right-3-cells-button").click();
+  }
+  if (event.key === 'e') {
+    document.getElementById("jump-right-4-cells-button").click();
+  }
+  if (event.key === 'r') {
+    document.getElementById("jump-right-5-cells-button").click();
+  }
+  if (event.key === 't') {
+    document.getElementById("jump-right-6-cells-button").click();
+  }
+  if (event.key === 'y') {
+    document.getElementById("jump-right-7-cells-button").click();
   }
 }

--- a/assets/app_js.js
+++ b/assets/app_js.js
@@ -35,28 +35,28 @@ function clickButtonFunction(event){
     document.getElementById("undo-button").click();
   }
   // Note: important that these ctrl+X shortcuts come before simple X ones (b/c using ifs not else ifs)
-  if (event.ctrlKey && event.key === '2') {
+  if (event.key === 'q') {
     document.getElementById("jump-right-2-cells-button").click();
   }
-  if (event.ctrlKey && event.key === '3') {
+  if (event.key === 'w') {
     document.getElementById("jump-right-3-cells-button").click();
   }
-  if (event.ctrlKey && event.key === '4') {
+  if (event.key === 'e') {
     document.getElementById("jump-right-4-cells-button").click();
   }
-  if (event.ctrlKey && event.key === '5') {
+  if (event.key === 'r') {
     document.getElementById("jump-right-5-cells-button").click();
   }
-  if (event.ctrlKey && event.key === '6') {
+  if (event.key === 't') {
     document.getElementById("jump-right-6-cells-button").click();
   }
-  if (event.ctrlKey && event.key === '7') {
+  if (event.key === 'y') {
     document.getElementById("jump-right-7-cells-button").click();
   }
-  if (event.ctrlKey && event.key === '8') {
+  if (event.key === 'u') {
     document.getElementById("jump-right-8-cells-button").click();
   }
-  if (event.ctrlKey && event.key === '9') {
+  if (event.key === 'i') {
     document.getElementById("jump-right-9-cells-button").click();
   }
   if(event.key == '1'){

--- a/assets/app_js.js
+++ b/assets/app_js.js
@@ -1,4 +1,4 @@
-document.addEventListener("keyup", clickButtonFunction);
+document.addEventListener("keydown", clickButtonFunction);
 
 function clickButtonFunction(event){
   if(event.key == 'ArrowLeft'){

--- a/assets/app_js.js
+++ b/assets/app_js.js
@@ -53,12 +53,6 @@ function clickButtonFunction(event){
   if (event.key === 'y') {
     document.getElementById("jump-right-7-cells-button").click();
   }
-  if (event.key === 'u') {
-    document.getElementById("jump-right-8-cells-button").click();
-  }
-  if (event.key === 'i') {
-    document.getElementById("jump-right-9-cells-button").click();
-  }
   if(event.key == '1'){
     document.getElementById("select-row-upto-1-button").click();
   }

--- a/assets/app_js.js
+++ b/assets/app_js.js
@@ -1,4 +1,4 @@
-document.addEventListener("keydown", clickButtonFunction);
+document.addEventListener("keyup", clickButtonFunction);
 
 function clickButtonFunction(event){
   if(event.key == 'ArrowLeft'){

--- a/selector_app.py
+++ b/selector_app.py
@@ -27,7 +27,7 @@ must be on the image itself.) You can remove an image from a group by double cli
 
 Additionally, one cell can have the special 'focus' class (currently blue border). This applies to one cell -
 another cell will lose this when it is superceded. This class is achieved by clicking on a cell (that doesn't already
-have it) or by moving the current highlighted cell around with the directional buttons / keys.
+have it) or by moving the current highlighted cell around with the directional buttons / keys (see Shortcuts).
 
 Once you've chosen the images in the group, you should begin to label those images with whether you want to keep them
 or not. Navigate to the image (directional keys or by clicking), then choose the 'Keep' or 'Delete' button to mark with

--- a/selector_app.py
+++ b/selector_app.py
@@ -743,6 +743,14 @@ def create_reactive_image_grid(n_row, n_col, image_list, image_data, image_path)
          Input('select-row-upto-8-button', 'n_clicks'),
          Input('select-row-upto-9-button', 'n_clicks'),
          Input('select-row-upto-1000-button', 'n_clicks'),
+         Input('jump-right-2-cells-button', 'n_clicks'),
+         Input('jump-right-3-cells-button', 'n_clicks'),
+         Input('jump-right-4-cells-button', 'n_clicks'),
+         Input('jump-right-5-cells-button', 'n_clicks'),
+         Input('jump-right-6-cells-button', 'n_clicks'),
+         Input('jump-right-7-cells-button', 'n_clicks'),
+         Input('jump-right-8-cells-button', 'n_clicks'),
+         Input('jump-right-9-cells-button', 'n_clicks'),
          Input('keep-button', 'n_clicks'),
          Input('delete-button', 'n_clicks'),
          Input('image-container', 'data'),
@@ -756,6 +764,7 @@ def activate_deactivate_cells(
         n_rows, n_cols,
         n_left, n_right, n_up, n_down,
         n_row1, n_row2, n_row3, n_row4, n_row5, n_row6, n_row7, n_row8, n_row9, n_row1000,
+        n_jump_r2, n_jump_r3, n_jump_r4, n_jump_r5, n_jump_r6, n_jump_r7, n_jump_r8, n_jump_r9,
         n_keep, n_delete,
         image_list, image_size_list, image_data, image_path, *args
     ):
@@ -776,6 +785,7 @@ def activate_deactivate_cells(
         n_up = int, number of clicks on the 'move-up' button (indicates shifting)
         n_down = int, number of clicks on the 'move-down' button (indicates shifting)
         n_row1,..9,1000 = int, number of clicks on the 'select row *' button (indicates shortcut to select many rows)
+        n_jump_r1,..9 = int, number of clicks on the 'jump right *' button (indicates shortcut to jump several cells)
         n_keep = int, number of clicks on the 'keep-button' button
         n_delete = int, number of clicks on the 'delete-button' button
         image_list = list, of str, specifying where the image files are stored
@@ -845,6 +855,16 @@ def activate_deactivate_cells(
     elif 'move-' in button_id:
         current_classes, zoomed_img, cell_last_clicked = utils.direction_key_pressed(
             button_id, n_rows, n_cols, COLS_MAX, ROWS_MAX * COLS_MAX, image_list, image_size_list, EMPTY_IMAGE, config.IMG_STYLE_ZOOM, *args
+        )
+        return current_classes + [zoomed_img, cell_last_clicked]
+
+    elif 'jump-' in button_id:
+        jump_left = 'left-' in button_id
+        n_cells_patt = 'jump-left-([0-9]+)-cells-button' if jump_left else 'jump-right-([0-9]+)-cells-button'
+        n_cells = int(re.findall(n_cells_patt, button_id)[0])
+
+        current_classes, zoomed_img, cell_last_clicked = utils.jump_focus_n_cells(
+            jump_left, n_cells, n_rows, n_cols, COLS_MAX, ROWS_MAX * COLS_MAX, image_list, image_size_list, EMPTY_IMAGE, config.IMG_STYLE_ZOOM, *args
         )
         return current_classes + [zoomed_img, cell_last_clicked]
 

--- a/selector_app.py
+++ b/selector_app.py
@@ -366,8 +366,25 @@ app.layout = html.Div(
             html.Td([
                 html.Button(id='jump-right-7-cells-button', style={'width': '10vw', })
             ]),
-
-            #
+            # Jump left buttons
+            html.Td([
+                html.Button(id='jump-left-2-cells-button', style={'width': '10vw', })
+            ]),
+            html.Td([
+                html.Button(id='jump-left-3-cells-button', style={'width': '10vw', })
+            ]),
+            html.Td([
+                html.Button(id='jump-left-4-cells-button', style={'width': '10vw', })
+            ]),
+            html.Td([
+                html.Button(id='jump-left-5-cells-button', style={'width': '10vw', })
+            ]),
+            html.Td([
+                html.Button(id='jump-left-6-cells-button', style={'width': '10vw', })
+            ]),
+            html.Td([
+                html.Button(id='jump-left-7-cells-button', style={'width': '10vw', })
+            ]),
         ], style={'display': 'none'}),
         # Store the number of images
         dcc.Store(id='n_images', data=[config.N_IMG_SRCS]),
@@ -751,6 +768,12 @@ def create_reactive_image_grid(n_row, n_col, image_list, image_data, image_path)
          Input('jump-right-5-cells-button', 'n_clicks'),
          Input('jump-right-6-cells-button', 'n_clicks'),
          Input('jump-right-7-cells-button', 'n_clicks'),
+         Input('jump-left-2-cells-button', 'n_clicks'),
+         Input('jump-left-3-cells-button', 'n_clicks'),
+         Input('jump-left-4-cells-button', 'n_clicks'),
+         Input('jump-left-5-cells-button', 'n_clicks'),
+         Input('jump-left-6-cells-button', 'n_clicks'),
+         Input('jump-left-7-cells-button', 'n_clicks'),
          Input('keep-button', 'n_clicks'),
          Input('delete-button', 'n_clicks'),
          Input('group-button', 'n_clicks'),
@@ -766,6 +789,7 @@ def activate_deactivate_cells(
         n_left, n_right, n_up, n_down,
         n_row1, n_row2, n_row3, n_row4, n_row5, n_row6, n_row7, n_row8, n_row9, n_row1000,
         n_jump_r2, n_jump_r3, n_jump_r4, n_jump_r5, n_jump_r6, n_jump_r7,
+        n_jump_l2, n_jump_l3, n_jump_l4, n_jump_l5, n_jump_l6, n_jump_l7,
         n_keep, n_delete, n_group,
         image_list, image_size_list, image_data, image_path, *args
     ):
@@ -787,6 +811,7 @@ def activate_deactivate_cells(
         n_down = int, number of clicks on the 'move-down' button (indicates shifting)
         n_row1,..9,1000 = int, number of clicks on the 'select row *' button (indicates shortcut to select many rows)
         n_jump_r1,..7 = int, number of clicks on the 'jump right *' button (indicates shortcut to jump several cells)
+        n_jump_l1,..7 = int, number of clicks on the 'jump left *' button (indicates shortcut to jump several cells)
         n_keep = int, number of clicks on the 'keep-button' button
         n_delete = int, number of clicks on the 'delete-button' button
         n_group = int, number of clicks on the 'group-button' button

--- a/selector_app.py
+++ b/selector_app.py
@@ -134,6 +134,16 @@ app.layout = html.Div(
                             html.Td("Move focus up / down")
                         ]),
                         html.Tr([
+                            html.Td("Q,W,E,R,T,Y"),
+                            html.Td("\t\t\t\t\t\t"),
+                            html.Td("Move focus 2,3,4,5,6,7 cells left")
+                        ]),
+                        html.Tr([
+                            html.Td("q,w,e,r,t,y"),
+                            html.Td("\t\t\t\t\t\t"),
+                            html.Td("Move focus 2,3,4,5,6,7 cells right")
+                        ]),
+                        html.Tr([
                             html.Td("g"),
                             html.Td("\t\t\t\t\t\t"),
                             html.Td("Add or remove image from group")

--- a/selector_app.py
+++ b/selector_app.py
@@ -339,6 +339,33 @@ app.layout = html.Div(
                     style={'width': '10vw', }
                 )
             ]),
+            # Jump right buttons
+            html.Td([
+                html.Button(id='jump-right-2-cells-button', style={'width': '10vw', })
+            ]),
+            html.Td([
+                html.Button(id='jump-right-3-cells-button', style={'width': '10vw', })
+            ]),
+            html.Td([
+                html.Button(id='jump-right-4-cells-button', style={'width': '10vw', })
+            ]),
+            html.Td([
+                html.Button(id='jump-right-5-cells-button', style={'width': '10vw', })
+            ]),
+            html.Td([
+                html.Button(id='jump-right-6-cells-button', style={'width': '10vw', })
+            ]),
+            html.Td([
+                html.Button(id='jump-right-7-cells-button', style={'width': '10vw', })
+            ]),
+            html.Td([
+                html.Button(id='jump-right-8-cells-button', style={'width': '10vw', })
+            ]),
+            html.Td([
+                html.Button(id='jump-right-9-cells-button', style={'width': '10vw', })
+            ]),
+
+            #
         ], style={'display': 'none'}),
         # Store the number of images
         dcc.Store(id='n_images', data=[config.N_IMG_SRCS]),

--- a/selector_app.py
+++ b/selector_app.py
@@ -366,12 +366,6 @@ app.layout = html.Div(
             html.Td([
                 html.Button(id='jump-right-7-cells-button', style={'width': '10vw', })
             ]),
-            html.Td([
-                html.Button(id='jump-right-8-cells-button', style={'width': '10vw', })
-            ]),
-            html.Td([
-                html.Button(id='jump-right-9-cells-button', style={'width': '10vw', })
-            ]),
 
             #
         ], style={'display': 'none'}),
@@ -757,8 +751,6 @@ def create_reactive_image_grid(n_row, n_col, image_list, image_data, image_path)
          Input('jump-right-5-cells-button', 'n_clicks'),
          Input('jump-right-6-cells-button', 'n_clicks'),
          Input('jump-right-7-cells-button', 'n_clicks'),
-         Input('jump-right-8-cells-button', 'n_clicks'),
-         Input('jump-right-9-cells-button', 'n_clicks'),
          Input('keep-button', 'n_clicks'),
          Input('delete-button', 'n_clicks'),
          Input('group-button', 'n_clicks'),
@@ -773,7 +765,7 @@ def activate_deactivate_cells(
         n_rows, n_cols,
         n_left, n_right, n_up, n_down,
         n_row1, n_row2, n_row3, n_row4, n_row5, n_row6, n_row7, n_row8, n_row9, n_row1000,
-        n_jump_r2, n_jump_r3, n_jump_r4, n_jump_r5, n_jump_r6, n_jump_r7, n_jump_r8, n_jump_r9,
+        n_jump_r2, n_jump_r3, n_jump_r4, n_jump_r5, n_jump_r6, n_jump_r7,
         n_keep, n_delete, n_group,
         image_list, image_size_list, image_data, image_path, *args
     ):
@@ -794,7 +786,7 @@ def activate_deactivate_cells(
         n_up = int, number of clicks on the 'move-up' button (indicates shifting)
         n_down = int, number of clicks on the 'move-down' button (indicates shifting)
         n_row1,..9,1000 = int, number of clicks on the 'select row *' button (indicates shortcut to select many rows)
-        n_jump_r1,..9 = int, number of clicks on the 'jump right *' button (indicates shortcut to jump several cells)
+        n_jump_r1,..7 = int, number of clicks on the 'jump right *' button (indicates shortcut to jump several cells)
         n_keep = int, number of clicks on the 'keep-button' button
         n_delete = int, number of clicks on the 'delete-button' button
         n_group = int, number of clicks on the 'group-button' button

--- a/utils.py
+++ b/utils.py
@@ -594,6 +594,40 @@ def direction_key_pressed(
     return new_classes, zoomed_img, cell_last_clicked
 
 
+def jump_focus_n_cells(
+        jump_left: bool, n_cells: int,
+        n_rows: int, n_cols: int, cols_max: int, n_grid: int,
+        image_list: List[str],
+        image_size_list: List[str],
+        empty_image: html.Img,
+        zoom_img_style: Dict[str, str],
+        *args
+    ):
+    # Get the last clicked cell from args
+    cell_last_clicked = args[-1]
+
+    # Get the classes from args and only change the value of the affected cell
+    new_classes = list(args[n_grid:-1])
+    if not cell_last_clicked:
+        cell_last_clicked = [0,0]
+    i_src, j_src = cell_last_clicked
+    idx_src = i_src * cols_max + j_src
+    my_class = new_classes[idx_src]
+
+    i_dest = i_src
+    j_dest = (j_src - n_cells) % n_cols if jump_left else (j_src + n_cells) % n_cols
+    idx_dest = i_dest * cols_max + j_dest
+
+    assert 'focus' in my_class
+    new_classes[idx_src] = ' '.join(class_toggle_focus(my_class.split(' ')))  # remove focus from original cell
+    class_dest = new_classes[idx_dest]
+    new_classes[idx_dest] = ' '.join(class_toggle_focus(class_dest.split(' ')))  # add focus to destination cell
+
+    cell_last_clicked = [i_dest, j_dest]
+    zoomed_img = html.Img(src=image_list[idx_dest], style=zoom_img_style, title=image_size_list[idx_dest]) if len(image_list) > 0 else empty_image
+    return new_classes, zoomed_img, cell_last_clicked
+
+
 def keep_delete_pressed(
         button_id: str,
         n_cols: int, cols_max: int, n_grid: int,


### PR DESCRIPTION
This change introduces a few extra shortcuts - qwerty and QWERTY keys - that allow the user to jump multiple cells at once, right and left respectively. This can help to reduce the amount of mouse work when you want to compare images that are not adjacent.

Note: left-right is the most common direction, so we omit up-down for the time being.